### PR TITLE
replace module with exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,13 @@
   "name": "parse-md",
   "version": "2.0.4",
   "description": "Separate markdown file's metadata from its content",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "./dist/cjs/index.cjs",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.cjs"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:rpearce/parse-md.git"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,3 @@
-import { dirname } from 'path'
 import babel from 'rollup-plugin-babel'
 import commonjs from '@rollup/plugin-commonjs'
 import external from 'rollup-plugin-auto-external'
@@ -18,7 +17,8 @@ const plugins = [
 ]
 
 const esm = {
-  dir: dirname(pkg.module),
+  // needs to have an .mjs extension for ESM to work when pkg.type !== "module"
+  file: pkg.exports['.'].import,
   exports: 'named',
   format: 'esm',
   name: 'parse-md',
@@ -26,7 +26,7 @@ const esm = {
 }
 
 const cjs = {
-  dir: dirname(pkg.main),
+  file: pkg.exports['.'].require,
   exports: 'named',
   format: 'cjs',
   name: 'parse-md',

--- a/source/index.js
+++ b/source/index.js
@@ -1,4 +1,8 @@
-import { safeLoad } from 'js-yaml'
+import jsYaml from 'js-yaml'
+
+// we've got to do it this way because the ES importer in Node can't
+// destructure CommonJS modules at import time
+const { safeLoad } = jsYaml
 
 const findMetadataIndices = (mem, item, i) => {
   if (/^---/.test(item)) {


### PR DESCRIPTION
This PR attempts to fix #24 by defining the `exports` field in package.json. It follows the guidelines set in the Node docs on [package entrypoints](https://nodejs.org/docs/latest-v16.x/api/packages.html#package-entry-points).